### PR TITLE
Change deploy to use a GitHub Action

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -43,5 +43,11 @@ jobs:
       with:
         node-version: '14'
     - run: npm ci
-    - run: npm run deploy
+    - run: npm run predeploy
+    - name: Deploy to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@4.0.0
+      with:
+        branch: gh-pages # The branch the action should deploy to.
+            folder: build # The folder the action should deploy.
+
   

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -48,6 +48,6 @@ jobs:
       uses: JamesIves/github-pages-deploy-action@4.0.0
       with:
         branch: gh-pages # The branch the action should deploy to.
-            folder: build # The folder the action should deploy.
+        folder: build # The folder the action should deploy.
 
   

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -42,8 +42,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '14'
-    - run: git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-    - run: git config --local user.name "GitHub Actions"
     - run: npm ci
     - run: npm run predeploy
     - name: Deploy to GitHub Pages


### PR DESCRIPTION
Committing using `npm run deploy` wasn't working. This changes it to use [this action](https://github.com/marketplace/actions/deploy-to-github-pages).